### PR TITLE
Implement biometric auth with PIN fallback

### DIFF
--- a/main/java/com/example/capilux/MainActivity.kt
+++ b/main/java/com/example/capilux/MainActivity.kt
@@ -32,8 +32,8 @@ class MainActivity : ComponentActivity() {
             }
             CapiluxTheme(darkTheme = darkModeState.value) {
                 if (username != null) {
-                    // Si hay usuario, ir directamente a MainScreen
-                    AppNavigation(darkModeState, startDestination = "main/$username")
+                    // Si hay usuario, solicitar autenticación
+                    AppNavigation(darkModeState, startDestination = "auth")
                 } else {
                     // Si no, comenzar en ExplanationScreen
                     AppNavigation(darkModeState)

--- a/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -15,6 +15,7 @@ import com.example.capilux.screen.ResultsScreen
 import com.example.capilux.screen.ExplanationScreen
 import com.example.capilux.screen.FavoritesScreen
 import com.example.capilux.screen.UserCreationScreen
+import com.example.capilux.screen.AuthScreen
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -33,6 +34,9 @@ fun AppNavigation(
         }
         composable("userCreation") {
             UserCreationScreen(navController)
+        }
+        composable("auth") {
+            AuthScreen(navController)
         }
         composable("main/{username}") { backStackEntry ->
             // 1. Obtener el nombre de usuario de los argumentos de navegación

--- a/main/java/com/example/capilux/screen/AuthScreen.kt
+++ b/main/java/com/example/capilux/screen/AuthScreen.kt
@@ -1,0 +1,114 @@
+package com.example.capilux.screen
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavHostController
+
+@Composable
+fun AuthScreen(navController: NavHostController) {
+    val context = LocalContext.current
+    val activity = context as ComponentActivity
+    val sharedPrefs = remember { context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE) }
+    val savedPin = remember { sharedPrefs.getString("pin", "1234") ?: "1234" }
+
+    var showPin by remember {
+        mutableStateOf(
+            BiometricManager.from(context)
+                .canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) !=
+                    BiometricManager.BIOMETRIC_SUCCESS
+        )
+    }
+    var pin by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    val executor = remember { ContextCompat.getMainExecutor(context) }
+    val biometricPrompt = remember {
+        BiometricPrompt(activity, executor,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    val username = sharedPrefs.getString("username", "") ?: ""
+                    navController.navigate("main/$username") {
+                        popUpTo("auth") { inclusive = true }
+                    }
+                }
+
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON) {
+                        showPin = true
+                    }
+                }
+            })
+    }
+
+    val promptInfo = remember {
+        BiometricPrompt.PromptInfo.Builder()
+            .setTitle("Autenticación requerida")
+            .setSubtitle("Usa tu huella digital")
+            .setNegativeButtonText("Ingresar PIN")
+            .build()
+    }
+
+    LaunchedEffect(Unit) {
+        if (!showPin) {
+            biometricPrompt.authenticate(promptInfo)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        if (showPin) {
+            Text("Introduce tu PIN", fontWeight = FontWeight.Bold)
+            OutlinedTextField(
+                value = pin,
+                onValueChange = { pin = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp)
+            )
+            Button(
+                onClick = {
+                    if (pin == savedPin) {
+                        val username = sharedPrefs.getString("username", "") ?: ""
+                        navController.navigate("main/$username") {
+                            popUpTo("auth") { inclusive = true }
+                        }
+                    } else {
+                        error = "PIN incorrecto"
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("Ingresar")
+            }
+            error?.let {
+                Text(it, color = Color.Red, modifier = Modifier.padding(top = 8.dp))
+            }
+        }
+    }
+}

--- a/main/java/com/example/capilux/screen/UserCreationScreen.kt
+++ b/main/java/com/example/capilux/screen/UserCreationScreen.kt
@@ -252,6 +252,9 @@ fun UserCreationScreen(navController: NavHostController) {
                             val editor = sharedPreferences.edit()
                             editor.putString("username", username)
                             imageUri?.let { editor.putString("imageUri", it.toString()) }
+                            if (!sharedPreferences.contains("pin")) {
+                                editor.putString("pin", "1234")
+                            }
                             editor.apply()
 
                             // Navegar a la pantalla principal


### PR DESCRIPTION
## Summary
- add new `AuthScreen` using fingerprint when available
- store a default PIN and request it if needed
- integrate authentication screen in navigation
- adjust main activity to start on the auth screen

## Testing
- `./gradlew test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6869841c4e6c8330887bd3ef5ebbed90