### PR TITLE
Agregar autenticación biométrica y PIN

### DIFF
--- a/main/AndroidManifest.xml
+++ b/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <!-- Permisos -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/main/java/com/example/capilux/MainActivity.kt
+++ b/main/java/com/example/capilux/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.example.capilux.navigation.AppNavigation
+import com.example.capilux.auth.AuthScreen
 import com.example.capilux.screen.resetDialogFlag
 import com.example.capilux.ui.theme.CapiluxTheme
 import com.example.capilux.utils.getInitialDarkModePreference
@@ -22,21 +23,22 @@ class MainActivity : ComponentActivity() {
             val darkModeState = remember {
                 mutableStateOf(getInitialDarkModePreference(this))
             }
+            val isAuthenticated = remember { mutableStateOf(false) }
 
-            // Verificar si hay un usuario guardado
-            val sharedPrefs = getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
-            val username = sharedPrefs.getString("username", null)
-            if (!isCameraPermissionGranted(this)) {
-                // Solicitar permisos si no están concedidos
-                requestCameraPermission(this)
-            }
             CapiluxTheme(darkTheme = darkModeState.value) {
-                if (username != null) {
-                    // Si hay usuario, ir directamente a MainScreen
-                    AppNavigation(darkModeState, startDestination = "main/$username")
+                if (!isAuthenticated.value) {
+                    AuthScreen { isAuthenticated.value = true }
                 } else {
-                    // Si no, comenzar en ExplanationScreen
-                    AppNavigation(darkModeState)
+                    val sharedPrefs = getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
+                    val username = sharedPrefs.getString("username", null)
+                    if (!isCameraPermissionGranted(this)) {
+                        requestCameraPermission(this)
+                    }
+                    if (username != null) {
+                        AppNavigation(darkModeState, startDestination = "main/$username")
+                    } else {
+                        AppNavigation(darkModeState)
+                    }
                 }
             }
         }

--- a/main/java/com/example/capilux/auth/AuthScreen.kt
+++ b/main/java/com/example/capilux/auth/AuthScreen.kt
@@ -1,0 +1,102 @@
+package com.example.capilux.auth
+
+import android.app.Activity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+
+@Composable
+fun AuthScreen(onAuthenticated: () -> Unit) {
+    val context = LocalContext.current
+    val activity = context as FragmentActivity
+    val biometricManager = BiometricManager.from(context)
+
+    var showPin by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    if (showPin || biometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG) != BiometricManager.BIOMETRIC_SUCCESS) {
+        PinScreen(onAuthenticated)
+    } else {
+        LaunchedEffect(Unit) {
+            authenticateBiometric(activity, onAuthenticated) { errorMessage = it }
+        }
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text("Autenticación biométrica")
+                errorMessage?.let { Text(it) }
+                TextButton(onClick = { showPin = true }) {
+                    Text("Usar PIN")
+                }
+            }
+        }
+    }
+}
+
+private fun authenticateBiometric(activity: FragmentActivity, onSuccess: () -> Unit, onError: (String) -> Unit) {
+    val executor = ContextCompat.getMainExecutor(activity)
+    val promptInfo = BiometricPrompt.PromptInfo.Builder()
+        .setTitle("Iniciar sesión")
+        .setSubtitle("Escanea tu huella digital")
+        .setNegativeButtonText("Cancelar")
+        .build()
+    val biometricPrompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+        override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+            super.onAuthenticationSucceeded(result)
+            onSuccess()
+        }
+        override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+            super.onAuthenticationError(errorCode, errString)
+            onError(errString.toString())
+        }
+        override fun onAuthenticationFailed() {
+            super.onAuthenticationFailed()
+            onError("Autenticación fallida")
+        }
+    })
+    biometricPrompt.authenticate(promptInfo)
+}
+
+@Composable
+fun PinScreen(onAuthenticated: () -> Unit, correctPin: String = "1234") {
+    var pin by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("Introduce PIN")
+        OutlinedTextField(value = pin, onValueChange = { pin = it }, label = { Text("PIN") })
+        if (error) {
+            Text("PIN incorrecto")
+        }
+        Button(onClick = {
+            if (pin == correctPin) {
+                onAuthenticated()
+            } else {
+                error = true
+            }
+        }) {
+            Text("Entrar")
+        }
+    }
+}
+


### PR DESCRIPTION
## Resumen
- se añade `AuthScreen` para manejo de huella digital con opción de PIN
- se actualiza `MainActivity` para mostrar la nueva autenticación antes de navegar
- se agrega permiso `USE_BIOMETRIC` en el manifest

## Testing
- `./gradlew test` *(falla: no existe gradlew)*

------
https://chatgpt.com/codex/tasks/task_b_6869841c4e6c8330887bd3ef5ebbed90