### PR TITLE
Fix huella digital

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 
     <!-- Características -->
     <uses-permission android:name="android.permission.CAMERA" />

--- a/app/src/main/java/com/example/capilux/screen/LoginScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/LoginScreen.kt
@@ -57,6 +57,10 @@ fun LoginScreen(navController: NavHostController, useAltTheme: Boolean) {
         val info = BiometricPrompt.PromptInfo.Builder()
             .setTitle("Acceso biométrico")
             .setNegativeButtonText("Cancelar")
+            .setAllowedAuthenticators(
+                BiometricManager.Authenticators.BIOMETRIC_STRONG or
+                        BiometricManager.Authenticators.BIOMETRIC_WEAK
+            )
             .build()
         prompt.authenticate(info)
     }


### PR DESCRIPTION
## Summary
- habilitar permisos biométricos en el manifiesto
- permitir autenticadores fuertes y débiles en la pantalla de login

## Testing
- `./gradlew test` *(falló: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d2feb8e20833082d5fcea7d898e0c