### PR TITLE
Add pin recovery screen and preset security questions

### DIFF
--- a/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -39,6 +39,9 @@ fun AppNavigation(
         composable("auth") {
             AuthScreen(navController, altThemeState.value)
         }
+        composable("resetPin") {
+            ResetPinScreen(navController, altThemeState.value)
+        }
         composable("main") {
             val username = usernameState.value
             val sharedPrefs = remember { EncryptedPrefs.getPrefs(context) }


### PR DESCRIPTION
## Summary
- use preset questions in `SetupSecurityScreen`
- add a new `ResetPinScreen` for recovering the pin
- hook new screen to `AppNavigation`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_6875eb65bedc83309cc4aede71f44909