### PR TITLE
Mejora de pantallas y opción de cambiar PIN

### DIFF
--- a/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -89,7 +89,13 @@ fun AppNavigation(
                 .getString("last_captured_image", null)
             val imageUri = imageUriString?.let { Uri.parse(it) }
 
-            ResultsScreen(faceShape, recommendedStyles, imageUri)
+            ResultsScreen(
+                faceShape = faceShape,
+                recommendedStyles = recommendedStyles,
+                imageUri = imageUri,
+                navController = navController,
+                useAltTheme = altThemeState.value
+            )
         }
         composable("favorites") {
             FavoritesScreen()

--- a/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.example.capilux.components.ProfileImageLarge
@@ -139,6 +141,7 @@ fun ConfigScreen(
 
             // Idioma
             var showLanguageDialog by remember { mutableStateOf(false) }
+            var showChangePinDialog by remember { mutableStateOf(false) }
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).clickable { showLanguageDialog = true },
                 verticalAlignment = Alignment.CenterVertically,
@@ -149,6 +152,17 @@ fun ConfigScreen(
                     text = if (currentLanguage == "es") "Espa\u00f1ol" else "English",
                     color = Color.White.copy(alpha = 0.7f)
                 )
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .clickable { showChangePinDialog = true },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Cambiar PIN", color = Color.White)
             }
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -209,6 +223,101 @@ fun ConfigScreen(
                                 sharedPreferences.edit().putString("language", currentLanguage).apply()
                                 setAppLocale(context, currentLanguage)
                                 context.restartApp()
+                            }
+                        )
+                    }
+                )
+            }
+
+            if (showChangePinDialog) {
+                var currentPin by remember { mutableStateOf("") }
+                var newPin by remember { mutableStateOf("") }
+                var confirmPin by remember { mutableStateOf("") }
+                var error by remember { mutableStateOf("") }
+
+                BaseDialog(
+                    title = "Cambiar PIN",
+                    onDismiss = { showChangePinDialog = false },
+                    content = {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            OutlinedTextField(
+                                value = currentPin,
+                                onValueChange = { if (it.length <= 6) currentPin = it },
+                                label = { Text("PIN actual", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true
+                            )
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            OutlinedTextField(
+                                value = newPin,
+                                onValueChange = { if (it.length <= 6) newPin = it },
+                                label = { Text("Nuevo PIN", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true
+                            )
+
+                            Spacer(modifier = Modifier.height(8.dp))
+
+                            OutlinedTextField(
+                                value = confirmPin,
+                                onValueChange = { if (it.length <= 6) confirmPin = it },
+                                label = { Text("Confirmar PIN", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true
+                            )
+
+                            if (error.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(error, color = Color.Red)
+                            }
+                        }
+                    },
+                    confirmButton = {
+                        PrimaryButton(
+                            text = "Guardar",
+                            onClick = {
+                                if (currentPin == EncryptedPrefs.getPin(context) && newPin.length == 6 && newPin == confirmPin) {
+                                    EncryptedPrefs.savePin(context, newPin)
+                                    EncryptedPrefs.saveLastPins(context, newPin)
+                                    showChangePinDialog = false
+                                } else {
+                                    error = "Datos incorrectos"
+                                }
                             }
                         )
                     }

--- a/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -59,13 +61,24 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta elegida") },
+                    label = { Text("Pregunta elegida", color = Color.White) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
                     modifier = Modifier
                         .menuAnchor()
-                        .fillMaxWidth(0.8f)
+                        .fillMaxWidth(0.8f),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        focusedLabelColor = Color.White,
+                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                        focusedIndicatorColor = Color.White,
+                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                        cursorColor = Color.White
+                    )
                 )
 
                 ExposedDropdownMenu(
@@ -89,8 +102,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta") },
-                modifier = Modifier.fillMaxWidth(0.8f)
+                label = { Text("Respuesta", color = Color.White) },
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -98,9 +122,20 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = nuevoPin,
                 onValueChange = { if (it.length <= 6) nuevoPin = it },
-                label = { Text("Nuevo PIN") },
+                label = { Text("Nuevo PIN", color = Color.White) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
-                modifier = Modifier.fillMaxWidth(0.8f)
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -108,9 +143,20 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = confirmarPin,
                 onValueChange = { if (it.length <= 6) confirmarPin = it },
-                label = { Text("Confirmar PIN") },
+                label = { Text("Confirmar PIN", color = Color.White) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
-                modifier = Modifier.fillMaxWidth(0.8f)
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             if (error.isNotEmpty()) {
@@ -138,8 +184,10 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                 modifier = Modifier
                     .fillMaxWidth(0.6f)
                     .height(50.dp)
+                    .border(1.dp, Color.White, RoundedCornerShape(8.dp)),
+                colors = ButtonDefaults.buttonColors(containerColor = Color.Transparent)
             ) {
-                Text("Guardar", fontSize = 18.sp)
+                Text("Guardar", fontSize = 18.sp, color = Color.White)
             }
         }
     }

--- a/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
@@ -4,15 +4,11 @@ import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -25,20 +21,29 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.navigation.compose.rememberNavController
+import androidx.navigation.NavHostController
 import coil.compose.rememberAsyncImagePainter
 import com.example.capilux.ui.theme.PrimaryButton
 import com.example.capilux.ui.theme.SecondaryButton
+import com.example.capilux.ui.theme.backgroundGradient
 
 @Composable
-fun ResultsScreen(faceShape: String, recommendedStyles: List<String>, imageUri: Uri?) {
-    val navController = rememberNavController()
+fun ResultsScreen(
+    faceShape: String,
+    recommendedStyles: List<String>,
+    imageUri: Uri?,
+    navController: NavHostController,
+    useAltTheme: Boolean
+) {
+
+    val gradient = backgroundGradient(useAltTheme)
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black)
-            .padding(16.dp),
+            .background(gradient)
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(


### PR DESCRIPTION
## Resumen
- ResultsScreen ahora respeta el tema elegido y es scrollable
- ConfigScreen permite cambiar el PIN mediante un diálogo
- ResetPinScreen presenta campos con bordes y texto blanco y botón estilizado
- Navegación actualizada para pasar navController y tema a ResultsScreen

## Testing
- `./gradlew test` *(falla: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68766d09ad78833097d2e23d4e670823