### PR TITLE
Añadir cambio de PIN y mejoras visuales

### DIFF
--- a/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -89,7 +89,7 @@ fun AppNavigation(
                 .getString("last_captured_image", null)
             val imageUri = imageUriString?.let { Uri.parse(it) }
 
-            ResultsScreen(faceShape, recommendedStyles, imageUri)
+            ResultsScreen(faceShape, recommendedStyles, imageUri, altThemeState.value)
         }
         composable("favorites") {
             FavoritesScreen()

--- a/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import com.example.capilux.components.ProfileImageLarge
@@ -139,6 +140,7 @@ fun ConfigScreen(
 
             // Idioma
             var showLanguageDialog by remember { mutableStateOf(false) }
+            var showChangePinDialog by remember { mutableStateOf(false) }
             Row(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).clickable { showLanguageDialog = true },
                 verticalAlignment = Alignment.CenterVertically,
@@ -149,6 +151,14 @@ fun ConfigScreen(
                     text = if (currentLanguage == "es") "Espa\u00f1ol" else "English",
                     color = Color.White.copy(alpha = 0.7f)
                 )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp).clickable { showChangePinDialog = true },
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text("Cambiar PIN", color = Color.White)
             }
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -209,6 +219,105 @@ fun ConfigScreen(
                                 sharedPreferences.edit().putString("language", currentLanguage).apply()
                                 setAppLocale(context, currentLanguage)
                                 context.restartApp()
+                            }
+                        )
+                    }
+                )
+            }
+
+            if (showChangePinDialog) {
+                var currentPin by remember { mutableStateOf("") }
+                var newPin by remember { mutableStateOf("") }
+                var confirmPin by remember { mutableStateOf("") }
+                var error by remember { mutableStateOf("" ) }
+
+                BaseDialog(
+                    title = "Cambiar PIN",
+                    onDismiss = { showChangePinDialog = false },
+                    content = {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            OutlinedTextField(
+                                value = currentPin,
+                                onValueChange = { if (it.length <= 6) currentPin = it },
+                                label = { Text("PIN actual", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            OutlinedTextField(
+                                value = newPin,
+                                onValueChange = { if (it.length <= 6) newPin = it },
+                                label = { Text("Nuevo PIN", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            Spacer(modifier = Modifier.height(12.dp))
+
+                            OutlinedTextField(
+                                value = confirmPin,
+                                onValueChange = { if (it.length <= 6) confirmPin = it },
+                                label = { Text("Confirmar PIN", color = Color.White) },
+                                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                                colors = TextFieldDefaults.colors(
+                                    focusedContainerColor = Color.Transparent,
+                                    unfocusedContainerColor = Color.Transparent,
+                                    focusedTextColor = Color.White,
+                                    unfocusedTextColor = Color.White,
+                                    focusedLabelColor = Color.White,
+                                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                                    focusedIndicatorColor = Color.White,
+                                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                                    cursorColor = Color.White
+                                ),
+                                singleLine = true,
+                                modifier = Modifier.fillMaxWidth()
+                            )
+
+                            if (error.isNotEmpty()) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(error, color = Color.Red)
+                            }
+                        }
+                    },
+                    confirmButton = {
+                        PrimaryButton(
+                            text = "Guardar",
+                            onClick = {
+                                val savedPin = EncryptedPrefs.getPin(context)
+                                if (currentPin == savedPin && newPin.length == 6 && newPin == confirmPin) {
+                                    EncryptedPrefs.savePin(context, newPin)
+                                    EncryptedPrefs.saveLastPins(context, newPin)
+                                    showChangePinDialog = false
+                                } else {
+                                    error = "Datos incorrectos"
+                                }
                             }
                         )
                     }

--- a/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
@@ -2,6 +2,8 @@ package com.example.capilux.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -14,6 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import com.example.capilux.ui.theme.backgroundGradient
+import com.example.capilux.ui.theme.PrimaryButton
 import com.example.capilux.utils.EncryptedPrefs
 
 @Composable
@@ -41,7 +44,10 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             .background(gradient),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.verticalScroll(rememberScrollState())
+        ) {
             Text(
                 text = "Recuperar PIN",
                 color = Color.White,
@@ -59,13 +65,24 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta elegida") },
+                    label = { Text("Pregunta elegida", color = Color.White) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
                     modifier = Modifier
                         .menuAnchor()
-                        .fillMaxWidth(0.8f)
+                        .fillMaxWidth(0.8f),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedTextColor = Color.White,
+                        unfocusedTextColor = Color.White,
+                        focusedLabelColor = Color.White,
+                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                        focusedIndicatorColor = Color.White,
+                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                        cursorColor = Color.White
+                    )
                 )
 
                 ExposedDropdownMenu(
@@ -89,8 +106,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta") },
-                modifier = Modifier.fillMaxWidth(0.8f)
+                label = { Text("Respuesta", color = Color.White) },
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -98,9 +126,20 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = nuevoPin,
                 onValueChange = { if (it.length <= 6) nuevoPin = it },
-                label = { Text("Nuevo PIN") },
+                label = { Text("Nuevo PIN", color = Color.White) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
-                modifier = Modifier.fillMaxWidth(0.8f)
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -108,9 +147,20 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = confirmarPin,
                 onValueChange = { if (it.length <= 6) confirmarPin = it },
-                label = { Text("Confirmar PIN") },
+                label = { Text("Confirmar PIN", color = Color.White) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
-                modifier = Modifier.fillMaxWidth(0.8f)
+                modifier = Modifier.fillMaxWidth(0.8f),
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = Color.Transparent,
+                    unfocusedContainerColor = Color.Transparent,
+                    focusedTextColor = Color.White,
+                    unfocusedTextColor = Color.White,
+                    focusedLabelColor = Color.White,
+                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.White,
+                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
+                    cursorColor = Color.White
+                )
             )
 
             if (error.isNotEmpty()) {
@@ -120,7 +170,8 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            Button(
+            PrimaryButton(
+                text = "Guardar",
                 onClick = {
                     if (pregunta == EncryptedPrefs.getSecurityQuestion(context) &&
                         EncryptedPrefs.isSecurityAnswerCorrect(context, respuesta) &&
@@ -135,12 +186,8 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                         error = "Datos incorrectos"
                     }
                 },
-                modifier = Modifier
-                    .fillMaxWidth(0.6f)
-                    .height(50.dp)
-            ) {
-                Text("Guardar", fontSize = 18.sp)
-            }
+                modifier = Modifier.fillMaxWidth(0.6f)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -29,16 +31,23 @@ import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
 import com.example.capilux.ui.theme.PrimaryButton
 import com.example.capilux.ui.theme.SecondaryButton
+import com.example.capilux.ui.theme.backgroundGradient
 
 @Composable
-fun ResultsScreen(faceShape: String, recommendedStyles: List<String>, imageUri: Uri?) {
+fun ResultsScreen(
+    faceShape: String,
+    recommendedStyles: List<String>,
+    imageUri: Uri?,
+    useAltTheme: Boolean
+) {
     val navController = rememberNavController()
 
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.Black)
-            .padding(16.dp),
+            .background(backgroundGradient(useAltTheme))
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(


### PR DESCRIPTION
## Resumen
- ResultsScreen ahora respeta el tema y es desplazable
- ConfigScreen incluye opción de cambiar PIN con validación
- ResetPinScreen presenta campos con estilo blanco y botón primario
- Navegación actualizada para enviar el tema a ResultsScreen

## Testing
- `./gradlew test --no-daemon` *(falla por falta de SDK)*

------
https://chatgpt.com/codex/tasks/task_b_68766d09ad78833097d2e23d4e670823