### PR TITLE
Fix logout and dark text design

### DIFF
--- a/app/src/main/java/com/example/capilux/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MainScreen.kt
@@ -93,6 +93,7 @@ import com.example.capilux.ui.theme.backgroundGradient
 import com.example.capilux.utils.FaceFrameAnalyzer
 import com.example.capilux.utils.compressImage
 import com.example.capilux.utils.takePhoto
+import com.example.capilux.utils.EncryptedPrefs
 import kotlinx.coroutines.launch
 import androidx.compose.material3.AlertDialog as MaterialAlertDialog
 
@@ -351,17 +352,12 @@ fun MainScreen(
                         Button(
                             onClick = {
                                 // Lógica para cerrar sesión
-                                val sharedPrefs =
-                                    context.getSharedPreferences("user_prefs", Context.MODE_PRIVATE)
-                                with(sharedPrefs.edit()) {
-                                    remove("username")
-                                    remove("imageUri")
-                                    apply()
-                                }
+                                EncryptedPrefs.setUsername(context, "")
+                                EncryptedPrefs.setImageUri(context, null)
 
-                                // Navegar a la pantalla de bienvenida y limpiar el backstack
-                                navController.navigate("explanation") {
-                                    popUpTo(0) // Limpiar toda la pila de navegación
+                                // Navegar al flujo inicial limpiando la pila
+                                navController.navigate("splashDecision") {
+                                    popUpTo("splashDecision") { inclusive = true }
                                 }
 
                                 // Cerrar el menú lateral

--- a/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
@@ -23,6 +23,7 @@ import com.example.capilux.utils.EncryptedPrefs
 fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
     val context = LocalContext.current
     val gradient = backgroundGradient(useAltTheme)
+    val textColor = Color.Black
 
     val preguntas = listOf(
         "¿Nombre de tu primera mascota?",
@@ -50,7 +51,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
         ) {
             Text(
                 text = "Recuperar PIN",
-                color = Color.White,
+                color = textColor,
                 fontSize = 22.sp,
                 style = MaterialTheme.typography.headlineSmall
             )
@@ -65,7 +66,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta elegida", color = Color.White) },
+                    label = { Text("Pregunta elegida", color = textColor) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
@@ -75,13 +76,13 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                     colors = TextFieldDefaults.colors(
                         focusedContainerColor = Color.Transparent,
                         unfocusedContainerColor = Color.Transparent,
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White,
-                        focusedLabelColor = Color.White,
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                        focusedIndicatorColor = Color.White,
-                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                        cursorColor = Color.White
+                        focusedTextColor = textColor,
+                        unfocusedTextColor = textColor,
+                        focusedLabelColor = textColor,
+                        unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                        focusedIndicatorColor = textColor,
+                        unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                        cursorColor = textColor
                     )
                 )
 
@@ -91,7 +92,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                 ) {
                     preguntas.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option) },
+                            text = { Text(option, color = textColor) },
                             onClick = {
                                 pregunta = option
                                 expandPreguntas = false
@@ -106,18 +107,18 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta", color = Color.White) },
+                label = { Text("Respuesta", color = textColor) },
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 
@@ -126,19 +127,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = nuevoPin,
                 onValueChange = { if (it.length <= 6) nuevoPin = it },
-                label = { Text("Nuevo PIN", color = Color.White) },
+                label = { Text("Nuevo PIN", color = textColor) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 
@@ -147,19 +148,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = confirmarPin,
                 onValueChange = { if (it.length <= 6) confirmarPin = it },
-                label = { Text("Confirmar PIN", color = Color.White) },
+                label = { Text("Confirmar PIN", color = textColor) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 

--- a/app/src/main/java/com/example/capilux/screen/SetupSecurityScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SetupSecurityScreen.kt
@@ -43,6 +43,8 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
         ) == BiometricManager.BIOMETRIC_SUCCESS
     }
 
+    val textColor = Color.Black
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -52,7 +54,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = "Configura tu seguridad",
-                color = Color.White,
+                color = textColor,
                 fontSize = 22.sp,
                 style = MaterialTheme.typography.headlineSmall
             )
@@ -62,19 +64,19 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = pin,
                 onValueChange = { if (it.length <= 6) pin = it },
-                label = { Text("Elige un PIN de 6 dígitos", color = Color.White) },
+                label = { Text("Elige un PIN de 6 dígitos", color = textColor) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 
@@ -83,19 +85,19 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = confirmPin,
                 onValueChange = { if (it.length <= 6) confirmPin = it },
-                label = { Text("Confirma tu PIN", color = Color.White) },
+                label = { Text("Confirma tu PIN", color = textColor) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 
@@ -115,12 +117,12 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                         checked = activarHuella,
                         onCheckedChange = { activarHuella = it },
                         colors = CheckboxDefaults.colors(
-                            checkedColor = Color.White,
-                            uncheckedColor = Color.White,
+                            checkedColor = textColor,
+                            uncheckedColor = textColor,
                             checkmarkColor = Color(0xFF6A11CB)
                         )
                     )
-                    Text("Activar acceso con huella", color = Color.White)
+                    Text("Activar acceso con huella", color = textColor)
                 }
             }
 
@@ -134,7 +136,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta de seguridad", color = Color.White) },
+                    label = { Text("Pregunta de seguridad", color = textColor) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
@@ -144,13 +146,13 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                     colors = TextFieldDefaults.colors(
                         focusedContainerColor = Color.Transparent,
                         unfocusedContainerColor = Color.Transparent,
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White,
-                        focusedLabelColor = Color.White,
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                        focusedIndicatorColor = Color.White,
-                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                        cursorColor = Color.White
+                        focusedTextColor = textColor,
+                        unfocusedTextColor = textColor,
+                        focusedLabelColor = textColor,
+                        unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                        focusedIndicatorColor = textColor,
+                        unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                        cursorColor = textColor
                     )
                 )
 
@@ -160,7 +162,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                 ) {
                     preguntas.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option, color = Color.White) },
+                            text = { Text(option, color = textColor) },
                             onClick = {
                                 pregunta = option
                                 expandPreguntas = false
@@ -175,18 +177,18 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta secreta", color = Color.White) },
+                label = { Text("Respuesta secreta", color = textColor) },
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedTextColor = textColor,
+                    unfocusedTextColor = textColor,
+                    focusedLabelColor = textColor,
+                    unfocusedLabelColor = textColor.copy(alpha = 0.7f),
+                    focusedIndicatorColor = textColor,
+                    unfocusedIndicatorColor = textColor.copy(alpha = 0.5f),
+                    cursorColor = textColor
                 )
             )
 


### PR DESCRIPTION
## Summary
- fix logout action to reset user data and navigate to splash
- tweak security setup screen with dark text
- tweak reset PIN screen with dark text

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e460a518083308f0c91f776d46560