### PR TITLE
Fix logout and apply design tweaks

### DIFF
--- a/app/src/main/java/com/example/capilux/screen/AuthScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/AuthScreen.kt
@@ -26,6 +26,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavHostController
 import com.example.capilux.R
 import com.example.capilux.ui.theme.backgroundGradient
+import com.example.capilux.ui.theme.PrimaryButton
 import com.example.capilux.utils.EncryptedPrefs
 import java.util.concurrent.Executor
 
@@ -101,12 +102,12 @@ fun AuthScreen(navController: NavHostController, useAltTheme: Boolean) {
             Text(
                 text = "Bienvenido a Capilux",
                 fontSize = 22.sp,
-                color = Color.White,
+                color = Color.Black,
                 style = MaterialTheme.typography.headlineSmall
             )
 
             Spacer(modifier = Modifier.height(12.dp))
-            Text(text = status, color = Color.White.copy(alpha = 0.7f))
+            Text(text = status, color = Color.Black.copy(alpha = 0.7f))
 
             if (showPin) {
                 Spacer(modifier = Modifier.height(28.dp))
@@ -114,17 +115,28 @@ fun AuthScreen(navController: NavHostController, useAltTheme: Boolean) {
                 OutlinedTextField(
                     value = pin,
                     onValueChange = { if (it.length <= 6) pin = it },
-                    label = { Text("PIN", color = Color.White) },
-                    textStyle = LocalTextStyle.current.copy(color = Color.White, fontSize = 20.sp),
+                    label = { Text("PIN", color = Color.Black) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                     modifier = Modifier
                         .width(240.dp)
-                        .padding(4.dp)
+                        .padding(4.dp),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                        focusedIndicatorColor = Color.Black,
+                        unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                        cursorColor = Color.Black
+                    ),
+                    textStyle = LocalTextStyle.current.copy(fontSize = 20.sp)
                 )
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Button(
+                PrimaryButton(
                     onClick = {
                         if (pin == EncryptedPrefs.getPin(context)) {
                             navController.navigate("main") {
@@ -138,16 +150,14 @@ fun AuthScreen(navController: NavHostController, useAltTheme: Boolean) {
                     modifier = Modifier
                         .width(200.dp)
                         .height(48.dp)
-                ) {
-                    Text("Acceder", fontSize = 18.sp)
-                }
+                )
 
                 Spacer(modifier = Modifier.height(12.dp))
 
                 TextButton(onClick = {
                     navController.navigate("resetPin")
                 }) {
-                    Text("¿Olvidaste tu PIN?", color = Color.White.copy(alpha = 0.8f))
+                    Text("¿Olvidaste tu PIN?", color = Color.Black.copy(alpha = 0.8f))
                 }
             }
         }

--- a/app/src/main/java/com/example/capilux/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MainScreen.kt
@@ -358,10 +358,11 @@ fun MainScreen(
                                     remove("imageUri")
                                     apply()
                                 }
+                                EncryptedPrefs.clearSession(context)
 
-                                // Navegar a la pantalla de bienvenida y limpiar el backstack
-                                navController.navigate("explanation") {
-                                    popUpTo(0) // Limpiar toda la pila de navegación
+                                // Volver al inicio y limpiar el backstack
+                                navController.navigate("splashDecision") {
+                                    popUpTo(0)
                                 }
 
                                 // Cerrar el menú lateral

--- a/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResetPinScreen.kt
@@ -50,7 +50,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
         ) {
             Text(
                 text = "Recuperar PIN",
-                color = Color.White,
+                color = Color.Black,
                 fontSize = 22.sp,
                 style = MaterialTheme.typography.headlineSmall
             )
@@ -65,7 +65,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta elegida", color = Color.White) },
+                    label = { Text("Pregunta elegida", color = Color.Black) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
@@ -73,15 +73,15 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                         .menuAnchor()
                         .fillMaxWidth(0.8f),
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = Color.Transparent,
-                        unfocusedContainerColor = Color.Transparent,
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White,
-                        focusedLabelColor = Color.White,
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                        focusedIndicatorColor = Color.White,
-                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                        cursorColor = Color.White
+                        focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                        focusedIndicatorColor = Color.Black,
+                        unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                        cursorColor = Color.Black
                     )
                 )
 
@@ -91,7 +91,7 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
                 ) {
                     preguntas.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option) },
+                            text = { Text(option, color = Color.Black) },
                             onClick = {
                                 pregunta = option
                                 expandPreguntas = false
@@ -106,18 +106,18 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta", color = Color.White) },
+                label = { Text("Respuesta", color = Color.Black) },
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 
@@ -126,19 +126,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = nuevoPin,
                 onValueChange = { if (it.length <= 6) nuevoPin = it },
-                label = { Text("Nuevo PIN", color = Color.White) },
+                label = { Text("Nuevo PIN", color = Color.Black) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 
@@ -147,19 +147,19 @@ fun ResetPinScreen(navController: NavHostController, useAltTheme: Boolean) {
             OutlinedTextField(
                 value = confirmarPin,
                 onValueChange = { if (it.length <= 6) confirmarPin = it },
-                label = { Text("Confirmar PIN", color = Color.White) },
+                label = { Text("Confirmar PIN", color = Color.Black) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 

--- a/app/src/main/java/com/example/capilux/screen/SetupSecurityScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SetupSecurityScreen.kt
@@ -52,7 +52,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
                 text = "Configura tu seguridad",
-                color = Color.White,
+                color = Color.Black,
                 fontSize = 22.sp,
                 style = MaterialTheme.typography.headlineSmall
             )
@@ -62,19 +62,19 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = pin,
                 onValueChange = { if (it.length <= 6) pin = it },
-                label = { Text("Elige un PIN de 6 dígitos", color = Color.White) },
+                label = { Text("Elige un PIN de 6 dígitos", color = Color.Black) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 
@@ -83,19 +83,19 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = confirmPin,
                 onValueChange = { if (it.length <= 6) confirmPin = it },
-                label = { Text("Confirma tu PIN", color = Color.White) },
+                label = { Text("Confirma tu PIN", color = Color.Black) },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 
@@ -115,12 +115,12 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                         checked = activarHuella,
                         onCheckedChange = { activarHuella = it },
                         colors = CheckboxDefaults.colors(
-                            checkedColor = Color.White,
-                            uncheckedColor = Color.White,
+                            checkedColor = Color.Black,
+                            uncheckedColor = Color.Black,
                             checkmarkColor = Color(0xFF6A11CB)
                         )
                     )
-                    Text("Activar acceso con huella", color = Color.White)
+                    Text("Activar acceso con huella", color = Color.Black)
                 }
             }
 
@@ -134,7 +134,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                     value = pregunta,
                     onValueChange = {},
                     readOnly = true,
-                    label = { Text("Pregunta de seguridad", color = Color.White) },
+                    label = { Text("Pregunta de seguridad", color = Color.Black) },
                     trailingIcon = {
                         ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandPreguntas)
                     },
@@ -142,15 +142,15 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                         .menuAnchor()
                         .fillMaxWidth(0.8f),
                     colors = TextFieldDefaults.colors(
-                        focusedContainerColor = Color.Transparent,
-                        unfocusedContainerColor = Color.Transparent,
-                        focusedTextColor = Color.White,
-                        unfocusedTextColor = Color.White,
-                        focusedLabelColor = Color.White,
-                        unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                        focusedIndicatorColor = Color.White,
-                        unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                        cursorColor = Color.White
+                        focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                        focusedTextColor = Color.Black,
+                        unfocusedTextColor = Color.Black,
+                        focusedLabelColor = Color.Black,
+                        unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                        focusedIndicatorColor = Color.Black,
+                        unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                        cursorColor = Color.Black
                     )
                 )
 
@@ -160,7 +160,7 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
                 ) {
                     preguntas.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option, color = Color.White) },
+                            text = { Text(option, color = Color.Black) },
                             onClick = {
                                 pregunta = option
                                 expandPreguntas = false
@@ -175,18 +175,18 @@ fun SetupSecurityScreen(navController: NavHostController, useAltTheme: Boolean) 
             OutlinedTextField(
                 value = respuesta,
                 onValueChange = { respuesta = it },
-                label = { Text("Respuesta secreta", color = Color.White) },
+                label = { Text("Respuesta secreta", color = Color.Black) },
                 modifier = Modifier.fillMaxWidth(0.8f),
                 colors = TextFieldDefaults.colors(
-                    focusedContainerColor = Color.Transparent,
-                    unfocusedContainerColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    focusedLabelColor = Color.White,
-                    unfocusedLabelColor = Color.White.copy(alpha = 0.7f),
-                    focusedIndicatorColor = Color.White,
-                    unfocusedIndicatorColor = Color.White.copy(alpha = 0.5f),
-                    cursorColor = Color.White
+                    focusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    unfocusedContainerColor = Color.White.copy(alpha = 0.3f),
+                    focusedTextColor = Color.Black,
+                    unfocusedTextColor = Color.Black,
+                    focusedLabelColor = Color.Black,
+                    unfocusedLabelColor = Color.Black.copy(alpha = 0.7f),
+                    focusedIndicatorColor = Color.Black,
+                    unfocusedIndicatorColor = Color.Black.copy(alpha = 0.5f),
+                    cursorColor = Color.Black
                 )
             )
 

--- a/app/src/main/java/com/example/capilux/utils/EncryptedPrefs.kt
+++ b/app/src/main/java/com/example/capilux/utils/EncryptedPrefs.kt
@@ -92,4 +92,19 @@ object EncryptedPrefs {
     fun getImageUri(context: Context): String? {
         return getPrefs(context).getString(KEY_IMAGE_URI, null)
     }
+
+    fun clearSession(context: Context) {
+        val prefs = getPrefs(context)
+        prefs.edit().apply {
+            remove(KEY_USERNAME)
+            remove(KEY_IMAGE_URI)
+            remove(KEY_PIN)
+            remove(KEY_LAST_PINS)
+            remove(KEY_BIOMETRICS)
+            remove(KEY_SECURITY_Q)
+            remove(KEY_SECURITY_A)
+            remove(KEY_SETUP_DONE)
+            apply()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- limpiamos completamente la sesión en `EncryptedPrefs`
- actualizamos la pantalla de autenticación con campos oscuros y botón primario
- al cerrar sesión se navega a `splashDecision` para comenzar de nuevo

## Testing
- `./gradlew test` *(falló: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e460a518083308f0c91f776d46560