### PR TITLE
Add help and support screen

### DIFF
--- a/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -94,6 +94,9 @@ fun AppNavigation(
         composable("favorites") {
             FavoritesScreen()
         }
+        composable("support") {
+            SupportScreen(navController, altThemeState.value)
+        }
         composable(
             route = "errorScreen/{message}",
             arguments = listOf(navArgument("message") { type = NavType.StringType })

--- a/app/src/main/java/com/example/capilux/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MainScreen.kt
@@ -306,28 +306,11 @@ fun MainScreen(
                         )
 
                         NavigationDrawerItem(
-                            label = { Text("Editar perfil", color = Color.White) },
-                            selected = false,
-                            onClick = {
-                                scope.launch { drawerState.close() }
-                                navController.navigate("userEdit")
-                            },
-                            icon = {
-                                Icon(
-                                    Icons.Filled.Edit,
-                                    contentDescription = "Editar perfil",
-                                    tint = Color.White
-                                )
-                            },
-                            modifier = Modifier.padding(vertical = 4.dp)
-                        )
-
-                        NavigationDrawerItem(
                             label = { Text("Ayuda y soporte", color = Color.White) },
                             selected = false,
                             onClick = {
                                 scope.launch { drawerState.close() }
-                                // navController.navigate("support") - Implementar después
+                                navController.navigate("support")
                             },
                             icon = {
                                 Icon(

--- a/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
@@ -1,0 +1,112 @@
+package com.example.capilux.screen
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.example.capilux.R
+import com.example.capilux.ui.theme.backgroundGradient
+
+@Composable
+fun SupportScreen(navController: NavHostController, useAltTheme: Boolean) {
+    val gradient = backgroundGradient(useAltTheme)
+    val infiniteTransition = rememberInfiniteTransition(label = "LogoWiggle")
+    val offsetY by infiniteTransition.animateFloat(
+        initialValue = -6f,
+        targetValue = 6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(2000, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ), label = "OffsetY"
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Ayuda y soporte", color = Color.White) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atrás", tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                    titleContentColor = Color.White
+                )
+            )
+        },
+        containerColor = Color.Transparent
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(gradient)
+                .padding(innerPadding)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.logo),
+                contentDescription = "Logo",
+                modifier = Modifier
+                    .size(140.dp)
+                    .offset(y = offsetY.dp)
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Contacto",
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Email: soporte@capilux.com",
+                color = Color.White,
+                fontSize = 16.sp
+            )
+            Text(
+                text = "Teléfono: +1-555-1234",
+                color = Color.White,
+                fontSize = 16.sp
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Si tienes preguntas o necesitas ayuda con la aplicación, no dudes en escribirnos.",
+                color = Color.White,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `SupportScreen` composable with animated logo and contact info
- route "support" in `AppNavigation`
- remove "Editar perfil" from drawer and link support item

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e5748273083309f45a35af47bd9de