### PR TITLE
Add support screen

### DIFF
--- a/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/capilux/navigation/AppNavigation.kt
@@ -92,7 +92,13 @@ fun AppNavigation(
             ResultsScreen(faceShape, recommendedStyles, imageUri, altThemeState.value)
         }
         composable("favorites") {
-            FavoritesScreen()
+            FavoritesScreen(altThemeState.value)
+        }
+        composable("savedImages") {
+            SavedImagesScreen(navController, altThemeState.value)
+        }
+        composable("support") {
+            SupportScreen(navController, altThemeState.value)
         }
         composable(
             route = "errorScreen/{message}",

--- a/app/src/main/java/com/example/capilux/screen/FavoritesScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/FavoritesScreen.kt
@@ -1,46 +1,58 @@
 package com.example.capilux.screen
 
-import androidx.compose.foundation.layout.*
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.example.capilux.ui.theme.backgroundGradient
 
 @Composable
-fun FavoritesScreen() {
-    // Lista simulada de estilos favoritos
-    val favoriteStyles = listOf(
-        "Corte clásico",
-        "Peinado hacia atrás",
-        "Corte degradado",
-        "Undercut",
-        "Flequillo"
-    )
+fun FavoritesScreen(useAltTheme: Boolean) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("favorites", Context.MODE_PRIVATE) }
+    val favoriteStyles = prefs.getStringSet("styles", emptySet())!!.toList()
+    val gradient = backgroundGradient(useAltTheme)
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .background(gradient)
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
             text = "Estilos Favoritos",
-            style = MaterialTheme.typography.titleLarge
+            style = MaterialTheme.typography.titleLarge,
+            color = Color.White
         )
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        LazyColumn {
-            items(favoriteStyles) { style ->
-                Text(
-                    text = style,
-                    modifier = Modifier.padding(8.dp)
-                )
+        if (favoriteStyles.isEmpty()) {
+            Text("No has guardado estilos", color = Color.White)
+        } else {
+            LazyColumn {
+                items(favoriteStyles) { style ->
+                    Text(
+                        text = style,
+                        color = Color.White,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/capilux/screen/FilterPreviewScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/FilterPreviewScreen.kt
@@ -1,14 +1,26 @@
 package com.example.capilux.screen
 
+import android.content.Context
 import androidx.camera.core.CameraSelector
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Camera
+import androidx.compose.material.icons.filled.Cameraswitch
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -19,8 +31,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import coil.compose.rememberAsyncImagePainter
 import com.example.capilux.components.CameraPreview
 import com.example.capilux.navigation.getRecommendedFilters
+import com.example.capilux.utils.takePhoto
 
 @Composable
 fun FilterPreviewScreen(faceShape: String, navController: NavHostController) {
@@ -28,29 +42,104 @@ fun FilterPreviewScreen(faceShape: String, navController: NavHostController) {
     val cameraController = remember {
         LifecycleCameraController(context).apply {
             setEnabledUseCases(CameraController.IMAGE_CAPTURE)
+            cameraSelector = CameraSelector.DEFAULT_FRONT_CAMERA
         }
     }
     val filters = getRecommendedFilters(faceShape)
     val selectedIndex = remember { mutableStateOf(0) }
+    val capturedUri = remember { mutableStateOf<android.net.Uri?>(null) }
+    var isFrontCamera by remember { mutableStateOf(true) }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        CameraPreview(
-            modifier = Modifier.fillMaxSize(),
-            cameraController = cameraController
-        )
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(filters[selectedIndex.value])
-        )
-        Row(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(16.dp)
-        ) {
-            filters.forEachIndexed { index, _ ->
-                Button(onClick = { selectedIndex.value = index }) {
-                    Text("Filtro ${index + 1}")
+        if (capturedUri.value == null) {
+            CameraPreview(
+                modifier = Modifier.fillMaxSize(),
+                cameraController = cameraController
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(filters[selectedIndex.value])
+            )
+
+            IconButton(
+                onClick = {
+                    cameraController.cameraSelector = if (isFrontCamera) {
+                        CameraSelector.DEFAULT_BACK_CAMERA
+                    } else {
+                        CameraSelector.DEFAULT_FRONT_CAMERA
+                    }
+                    isFrontCamera = !isFrontCamera
+                },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+            ) {
+                Icon(Icons.Filled.Cameraswitch, contentDescription = "Cambiar c\u00e1mara", tint = Color.White)
+            }
+
+            LazyRow(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 80.dp)
+            ) {
+                itemsIndexed(filters) { index, color ->
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                            .size(56.dp)
+                            .background(color, CircleShape)
+                            .clickable { selectedIndex.value = index }
+                    )
+                }
+            }
+
+            FloatingActionButton(
+                onClick = {
+                    takePhoto(
+                        cameraController = cameraController,
+                        context = context,
+                        onSuccess = { uri -> capturedUri.value = uri },
+                        onError = { }
+                    )
+                },
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(24.dp)
+            ) {
+                Icon(Icons.Filled.Camera, contentDescription = "Tomar foto")
+            }
+        } else {
+            androidx.compose.foundation.Image(
+                painter = rememberAsyncImagePainter(capturedUri.value),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(filters[selectedIndex.value])
+            )
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(24.dp)
+            ) {
+                FloatingActionButton(onClick = { capturedUri.value = null }) {
+                    Icon(Icons.Filled.Cameraswitch, contentDescription = "Reintentar")
+                }
+                Spacer(modifier = Modifier.size(16.dp))
+                FloatingActionButton(
+                    onClick = {
+                        val prefs = context.getSharedPreferences("saved_images", Context.MODE_PRIVATE)
+                        val set = prefs.getStringSet("images", emptySet())?.toMutableSet() ?: mutableSetOf()
+                        capturedUri.value?.toString()?.let { set.add(it) }
+                        prefs.edit().putStringSet("images", set).apply()
+                        navController.navigate("savedImages")
+                    }
+                ) {
+                    Icon(Icons.Filled.Camera, contentDescription = "Guardar")
                 }
             }
         }

--- a/app/src/main/java/com/example/capilux/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MainScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Camera
 import androidx.compose.material.icons.filled.Cameraswitch
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Help
 import androidx.compose.material.icons.filled.History
@@ -273,6 +272,23 @@ fun MainScreen(
                             modifier = Modifier.padding(vertical = 4.dp)
                         )
 
+                        NavigationDrawerItem(
+                            label = { Text("Im\u00e1genes guardadas", color = Color.White) },
+                            selected = false,
+                            onClick = {
+                                scope.launch { drawerState.close() }
+                                navController.navigate("savedImages")
+                            },
+                            icon = {
+                                Icon(
+                                    Icons.Filled.History,
+                                    contentDescription = "Im\u00e1genes guardadas",
+                                    tint = Color.White
+                                )
+                            },
+                            modifier = Modifier.padding(vertical = 4.dp)
+                        )
+
                         // Divider
                         Divider(
                             color = Color.White.copy(alpha = 0.2f),
@@ -306,28 +322,11 @@ fun MainScreen(
                         )
 
                         NavigationDrawerItem(
-                            label = { Text("Editar perfil", color = Color.White) },
-                            selected = false,
-                            onClick = {
-                                scope.launch { drawerState.close() }
-                                navController.navigate("userEdit")
-                            },
-                            icon = {
-                                Icon(
-                                    Icons.Filled.Edit,
-                                    contentDescription = "Editar perfil",
-                                    tint = Color.White
-                                )
-                            },
-                            modifier = Modifier.padding(vertical = 4.dp)
-                        )
-
-                        NavigationDrawerItem(
                             label = { Text("Ayuda y soporte", color = Color.White) },
                             selected = false,
                             onClick = {
                                 scope.launch { drawerState.close() }
-                                // navController.navigate("support") - Implementar después
+                                navController.navigate("support")
                             },
                             icon = {
                                 Icon(

--- a/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ResultsScreen.kt
@@ -2,6 +2,7 @@ package com.example.capilux.screen
 
 import android.net.Uri
 import androidx.compose.foundation.Image
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
@@ -21,11 +22,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import coil.compose.rememberAsyncImagePainter
@@ -41,6 +44,8 @@ fun ResultsScreen(
     useAltTheme: Boolean
 ) {
     val navController = rememberNavController()
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("favorites", Context.MODE_PRIVATE) }
 
     Column(
         modifier = Modifier
@@ -107,7 +112,11 @@ fun ResultsScreen(
 
         PrimaryButton(
             text = "Guardar resultados",
-            onClick = { /* Guardar resultados */ }
+            onClick = {
+                val current = prefs.getStringSet("styles", emptySet())?.toMutableSet() ?: mutableSetOf()
+                current.addAll(recommendedStyles)
+                prefs.edit().putStringSet("styles", current).apply()
+            }
         )
 
         Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
@@ -1,0 +1,87 @@
+package com.example.capilux.screen
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import android.content.Context
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import coil.compose.rememberAsyncImagePainter
+import com.example.capilux.ui.theme.backgroundGradient
+
+@Composable
+fun SavedImagesScreen(navController: NavHostController, useAltTheme: Boolean) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("saved_images", Context.MODE_PRIVATE) }
+    val images = prefs.getStringSet("images", emptySet())!!.toList()
+    val gradient = backgroundGradient(useAltTheme)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Im\u00e1genes guardadas", color = Color.White) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atr\u00e1s", tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                    titleContentColor = Color.White
+                )
+            )
+        },
+        containerColor = Color.Transparent
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(gradient)
+                .padding(innerPadding)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top
+        ) {
+            if (images.isEmpty()) {
+                Text("No hay im\u00e1genes guardadas", color = Color.White)
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                    items(images) { uriString ->
+                        Image(
+                            painter = rememberAsyncImagePainter(uriString),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(300.dp),
+                            contentScale = ContentScale.Crop
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
@@ -1,0 +1,108 @@
+package com.example.capilux.screen
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavHostController
+import com.example.capilux.R
+import com.example.capilux.ui.theme.backgroundGradient
+
+@Composable
+fun SupportScreen(navController: NavHostController, useAltTheme: Boolean) {
+    val gradient = backgroundGradient(useAltTheme)
+    val infiniteTransition = rememberInfiniteTransition(label = "logoFloat")
+    val offsetY by infiniteTransition.animateFloat(
+        initialValue = -6f,
+        targetValue = 6f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000),
+            repeatMode = RepeatMode.Reverse
+        ), label = "offsetY"
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Ayuda y soporte", color = Color.White) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atrás", tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Transparent,
+                    titleContentColor = Color.White
+                )
+            )
+        },
+        containerColor = Color.Transparent
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(gradient)
+                .padding(innerPadding)
+                .padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.logo),
+                contentDescription = "Logo Capilux",
+                modifier = Modifier
+                    .size(140.dp)
+                    .offset(y = offsetY.dp)
+            )
+            Spacer(modifier = Modifier.size(24.dp))
+            Text(
+                text = "¿Necesitas ayuda? Contáctanos en:",
+                color = Color.White,
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.size(12.dp))
+            Text(
+                text = "soporte@capilux.com",
+                color = Color.White,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp
+            )
+            Spacer(modifier = Modifier.size(4.dp))
+            Text(
+                text = "Teléfono: +1 234 567 890",
+                color = Color.White,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add help & support screen with animated logo
- update navigation to include support screen
- remove "Editar perfil" from drawer and make help item navigate

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e5748273083309f45a35af47bd9de