### PR TITLE
Mejorar diseño en SavedImagesScreen

### DIFF
--- a/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
@@ -2,8 +2,8 @@ package com.example.capilux.screen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,16 +12,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import android.content.Context
 import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -32,7 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -78,42 +79,49 @@ fun SavedImagesScreen(navController: NavHostController, useAltTheme: Boolean) {
             if (images.isEmpty()) {
                 Text("No hay im\u00e1genes guardadas", color = Color.White)
             } else {
-                LazyColumn(modifier = Modifier.fillMaxWidth()) {
-                    items(images) { uriString ->
-                        Column(modifier = Modifier
-                            .fillMaxWidth()
-                            .border(2.dp, Color.White, RectangleShape)) {
-                            Image(
-                                painter = rememberAsyncImagePainter(uriString),
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(300.dp),
-                                contentScale = ContentScale.Crop
-                            )
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(8.dp),
-                                horizontalArrangement = Arrangement.End
-                            ) {
-                                IconButton(onClick = {
-                                    if (saveImageToGallery(context, Uri.parse(uriString))) {
-                                        // Image saved
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    itemsIndexed(images) { index, uriString ->
+                        Card(
+                            modifier = Modifier.fillMaxWidth(),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = CardDefaults.cardColors(containerColor = Color.White.copy(alpha = 0.1f)),
+                            border = androidx.compose.foundation.BorderStroke(1.dp, Color.White.copy(alpha = 0.5f))
+                        ) {
+                            Box {
+                                Image(
+                                    painter = rememberAsyncImagePainter(uriString),
+                                    contentDescription = null,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(300.dp),
+                                    contentScale = ContentScale.Crop
+                                )
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(Color.Black.copy(alpha = 0.4f))
+                                        .padding(8.dp)
+                                        .align(Alignment.BottomEnd),
+                                    horizontalArrangement = Arrangement.End
+                                ) {
+                                    IconButton(onClick = {
+                                        saveImageToGallery(context, Uri.parse(uriString))
+                                    }) {
+                                        Icon(Icons.Filled.Download, contentDescription = "Descargar", tint = Color.White)
                                     }
-                                }) {
-                                    Icon(Icons.Filled.Download, contentDescription = "Descargar", tint = Color.White)
-                                }
-                                IconButton(onClick = {
-                                    deleteImageFile(context, uriString)
-                                    images.remove(uriString)
-                                    prefs.edit().putStringSet("images", images.toSet()).apply()
-                                }) {
-                                    Icon(Icons.Filled.Delete, contentDescription = "Eliminar", tint = Color.White)
+                                    IconButton(onClick = {
+                                        deleteImageFile(context, uriString)
+                                        images.remove(uriString)
+                                        prefs.edit().putStringSet("images", images.toSet()).apply()
+                                    }) {
+                                        Icon(Icons.Filled.Delete, contentDescription = "Eliminar", tint = Color.White)
+                                    }
                                 }
                             }
                         }
-                        Spacer(modifier = Modifier.height(16.dp))
                     }
                 }
             }


### PR DESCRIPTION
## Resumen
- actualizo SavedImagesScreen usando `Card` con esquinas redondeadas y una mejor disposición visual
- separo los elementos de la lista usando `LazyColumn` con espacio entre tarjetas

## Testing
- `./gradlew test --no-daemon` *(falla: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68824b1013608330b536304f71e5479b