### PR TITLE
feat: improve mask and style screens design

### DIFF
--- a/app/src/main/java/com/example/capilux/screen/GeneratedImageScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/GeneratedImageScreen.kt
@@ -6,7 +6,8 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -22,6 +23,8 @@ import androidx.navigation.NavHostController
 import com.example.capilux.SharedViewModel
 import com.example.capilux.network.CapiluxApi
 import com.example.capilux.utils.saveImageToGallery
+import com.example.capilux.ui.theme.PrimaryButton
+import com.example.capilux.ui.theme.SecondaryButton
 import com.example.capilux.ui.theme.backgroundGradient
 import kotlinx.coroutines.launch
 import java.io.File
@@ -48,13 +51,16 @@ fun GeneratedImageScreen(
         }
     }
 
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(gradient)
-            .padding(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(16.dp)
     ) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
         // Mostrar nombre del estilo
         Text(
             text = "Estilo aplicado: $promptVisible",
@@ -64,21 +70,25 @@ fun GeneratedImageScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (loading) {
-            CircularProgressIndicator()
-            Spacer(modifier = Modifier.height(16.dp))
-            Text("Regenerando imagen...", color = Color.White)
-        } else if (file.exists()) {
+        if (file.exists()) {
             val bitmap = BitmapFactory.decodeFile(file.absolutePath)
-            Image(
-                bitmap = bitmap.asImageBitmap(),
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = Color.Black.copy(alpha = 0.3f)
+                ),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(1f)
                     .padding(16.dp)
-            )
+            ) {
+                Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(1f)
+                )
+            }
         } else {
             Text("❌ No se encontró la imagen generada", color = Color.Red)
         }
@@ -90,7 +100,8 @@ fun GeneratedImageScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Button(
+        SecondaryButton(
+            text = "Volver al inicio",
             onClick = {
                 sharedViewModel.clearAll()
                 File(context.filesDir, "original_usuario.jpg").delete()
@@ -101,32 +112,27 @@ fun GeneratedImageScreen(
                 }
             },
             modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Volver al inicio")
-        }
+        )
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        Button(
-            onClick = {
-                saveImageToGallery(context, file)
-            },
+        PrimaryButton(
+            text = "Guardar imagen",
+            onClick = { saveImageToGallery(context, file) },
             modifier = Modifier.fillMaxWidth()
-        ) {
-            Text("Guardar imagen")
-        }
+        )
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        Button(
+        PrimaryButton(
+            text = "Regenerar resultado",
             onClick = {
-                // Lógica para regenerar imagen con el mismo prompt/archivos
                 val imageFile = File(context.filesDir, "original_usuario.jpg")
                 val maskFile = File(context.filesDir, "mascara_tmp.png")
                 val prompt = promptVisible
                 if (!imageFile.exists() || !maskFile.exists()) {
                     errorMessage = "No se encontró la imagen o la máscara original."
-                    return@Button
+                    return@PrimaryButton
                 }
                 loading = true
                 errorMessage = null
@@ -153,8 +159,31 @@ fun GeneratedImageScreen(
                 }
             },
             modifier = Modifier.fillMaxWidth()
+        )
+    }
+
+    if (loading) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.4f)),
+            contentAlignment = Alignment.Center
         ) {
-            Text("Regenerar resultado")
+            Card(
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.8f)
+                ),
+                shape = MaterialTheme.shapes.medium,
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    CircularProgressIndicator()
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text("Regenerando imagen...", color = Color.White)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/capilux/screen/MaskPreviewScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MaskPreviewScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
+import com.example.capilux.ui.theme.PrimaryButton
+import com.example.capilux.ui.theme.SecondaryButton
 import com.example.capilux.ui.theme.backgroundGradient
 import java.io.File
 
@@ -45,41 +47,50 @@ fun MaskPreviewScreen(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = Color.Black.copy(alpha = 0.3f)
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
         ) {
-            // Foto original
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Original", color = Color.White)
-                if (originalFile.exists()) {
-                    val bitmap = BitmapFactory.decodeFile(originalFile.absolutePath)
-                    Image(
-                        bitmap = bitmap.asImageBitmap(),
-                        contentDescription = "Imagen original",
-                        modifier = Modifier
-                            .size(160.dp)
-                            .padding(8.dp)
-                    )
-                } else {
-                    Text("❌ Sin imagen", color = Color.Red)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Original", color = Color.White)
+                    if (originalFile.exists()) {
+                        val bitmap = BitmapFactory.decodeFile(originalFile.absolutePath)
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "Imagen original",
+                            modifier = Modifier
+                                .size(160.dp)
+                                .padding(8.dp)
+                        )
+                    } else {
+                        Text("❌ Sin imagen", color = Color.Red)
+                    }
                 }
-            }
 
-            // Máscara generada
-            Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                Text("Máscara", color = Color.White)
-                if (maskFile.exists()) {
-                    val bitmap = BitmapFactory.decodeFile(maskFile.absolutePath)
-                    Image(
-                        bitmap = bitmap.asImageBitmap(),
-                        contentDescription = "Máscara",
-                        modifier = Modifier
-                            .size(160.dp)
-                            .padding(8.dp)
-                    )
-                } else {
-                    Text("❌ No generada", color = Color.Red)
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("Máscara", color = Color.White)
+                    if (maskFile.exists()) {
+                        val bitmap = BitmapFactory.decodeFile(maskFile.absolutePath)
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "Máscara",
+                            modifier = Modifier
+                                .size(160.dp)
+                                .padding(8.dp)
+                        )
+                    } else {
+                        Text("❌ No generada", color = Color.Red)
+                    }
                 }
             }
         }
@@ -87,25 +98,23 @@ fun MaskPreviewScreen(
         Spacer(modifier = Modifier.height(32.dp))
 
         // Botón para aceptar máscara y continuar a selección de estilos/cortes
-        Button(
+        PrimaryButton(
+            text = "Aceptar y continuar",
             onClick = {
                 navController.navigate("promptSelectionScreen/${Uri.encode(originalFile.absolutePath)}")
             },
             modifier = Modifier.fillMaxWidth(0.8f)
-        ) {
-            Text("Aceptar y continuar")
-        }
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
 
         // Botón para regenerar la máscara
-        Button(
+        SecondaryButton(
+            text = "Regenerar máscara",
             onClick = {
                 navController.navigate("maskProcessingScreen/${Uri.encode(originalFile.absolutePath)}")
             },
             modifier = Modifier.fillMaxWidth(0.8f)
-        ) {
-            Text("Regenerar máscara")
-        }
+        )
     }
 }

--- a/app/src/main/java/com/example/capilux/screen/MaskProcessingScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/MaskProcessingScreen.kt
@@ -78,24 +78,46 @@ fun MaskProcessingScreen(
     ) {
         when {
             loading.value -> {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Text("Generando máscara...", color = Color.White)
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = Color.Black.copy(alpha = 0.4f)
+                    ),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.padding(24.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator()
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text("Generando máscara...", color = Color.White)
+                    }
                 }
             }
             error.value != null -> {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(
-                        text = error.value ?: "Error desconocido",
-                        color = Color.Red,
-                        style = MaterialTheme.typography.bodyLarge
-                    )
-                    Spacer(modifier = Modifier.height(16.dp))
-                    Button(
-                        onClick = { navController.popBackStack() },
-                        modifier = Modifier.padding(top = 16.dp)
-                    ) { Text("Volver") }
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = Color.Black.copy(alpha = 0.4f)
+                    ),
+                    shape = MaterialTheme.shapes.medium,
+                    modifier = Modifier.padding(24.dp)
+                ) {
+                    Column(
+                        modifier = Modifier.padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = error.value ?: "Error desconocido",
+                            color = Color.Red,
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Button(
+                            onClick = { navController.popBackStack() },
+                            modifier = Modifier.padding(top = 16.dp)
+                        ) { Text("Volver") }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/capilux/screen/ProcessingScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ProcessingScreen.kt
@@ -5,6 +5,8 @@ import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -72,26 +74,37 @@ fun ProcessingScreen(
             .background(gradient),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Image(
-                painter = painterResource(id = R.drawable.logo),
-                contentDescription = "Logo",
-                modifier = Modifier.size(140.dp)
-            )
-            Spacer(modifier = Modifier.height(16.dp))
-            LinearProgressIndicator(
-                modifier = Modifier
-                    .width(180.dp)
-                    .height(5.dp),
-                color = MaterialTheme.colorScheme.primary,
-                trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
-            )
-            Spacer(modifier = Modifier.height(32.dp))
-            Text(
-                text = "Procesando tu rostro...",
-                color = MaterialTheme.colorScheme.onBackground,
-                style = MaterialTheme.typography.bodyMedium
-            )
+        Card(
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.background.copy(alpha = 0.6f)
+            ),
+            shape = MaterialTheme.shapes.medium,
+            modifier = Modifier.padding(24.dp)
+        ) {
+            Column(
+                modifier = Modifier.padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.logo),
+                    contentDescription = "Logo",
+                    modifier = Modifier.size(140.dp)
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                LinearProgressIndicator(
+                    modifier = Modifier
+                        .width(180.dp)
+                        .height(5.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    trackColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+                Text(
+                    text = "Procesando tu rostro...",
+                    color = MaterialTheme.colorScheme.onBackground,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- polish mask generation preview with cards and themed buttons
- add card-based progress UIs for mask creation, face analysis and style generation
- revamp generated image result screen with overlay loader and styled actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68920e3c21d4832f95d9c7c09882af7d