### PR TITLE
Add English localization and saved image support

### DIFF
--- a/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ConfigScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import com.example.capilux.components.ProfileImageLarge
 import com.example.capilux.ui.theme.*
@@ -27,6 +28,7 @@ import com.example.capilux.utils.compressImage
 import com.example.capilux.utils.restartApp
 import com.example.capilux.utils.setAppLocale
 import com.example.capilux.utils.EncryptedPrefs
+import com.example.capilux.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,10 +65,10 @@ fun ConfigScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Configuraci\u00f3n", color = Color.White) },
+                title = { Text(stringResource(R.string.config_title), color = Color.White) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atr\u00e1s", tint = Color.White)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(R.string.back), tint = Color.White)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -95,7 +97,7 @@ fun ConfigScreen(
             OutlinedTextField(
                 value = editedUsername,
                 onValueChange = { editedUsername = it },
-                label = { Text("Nombre", color = Color.White) },
+                label = { Text(stringResource(R.string.config_name_label), color = Color.White) },
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,
@@ -112,7 +114,7 @@ fun ConfigScreen(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            Text("Configuraciones", color = Color.White, style = MaterialTheme.typography.titleMedium)
+            Text(stringResource(R.string.config_section_settings), color = Color.White, style = MaterialTheme.typography.titleMedium)
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -122,7 +124,7 @@ fun ConfigScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Degradado", color = Color.White)
+                Text(stringResource(R.string.config_gradient), color = Color.White)
                 Switch(
                     checked = altThemeEnabled,
                     onCheckedChange = {
@@ -147,9 +149,9 @@ fun ConfigScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Idioma", color = Color.White)
+                Text(stringResource(R.string.config_language), color = Color.White)
                 Text(
-                    text = if (currentLanguage == "es") "Espa\u00f1ol" else "English",
+                    text = if (currentLanguage == "es") stringResource(R.string.lang_spanish) else stringResource(R.string.lang_english),
                     color = Color.White.copy(alpha = 0.7f)
                 )
             }
@@ -159,13 +161,13 @@ fun ConfigScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
-                Text("Cambiar PIN", color = Color.White)
+                Text(stringResource(R.string.config_change_pin), color = Color.White)
             }
 
             Spacer(modifier = Modifier.height(32.dp))
 
             PrimaryButton(
-                text = "Guardar cambios",
+                text = stringResource(R.string.config_save_changes),
                 onClick = {
                     EncryptedPrefs.setUsername(context, editedUsername)
                     usernameState.value = editedUsername
@@ -179,13 +181,13 @@ fun ConfigScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             SecondaryButton(
-                text = "Volver",
+                text = stringResource(R.string.back),
                 onClick = { navController.popBackStack() }
             )
 
             if (showLanguageDialog) {
                 BaseDialog(
-                    title = "Seleccionar idioma",
+                    title = stringResource(R.string.config_select_language),
                     onDismiss = { showLanguageDialog = false },
                     content = {
                         Column {
@@ -198,7 +200,7 @@ fun ConfigScreen(
                                         unselectedColor = Color.White
                                     )
                                 )
-                                Text("Espa\u00f1ol", color = Color.White)
+                                Text(stringResource(R.string.lang_spanish), color = Color.White)
                             }
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 RadioButton(
@@ -209,13 +211,13 @@ fun ConfigScreen(
                                         unselectedColor = Color.White
                                     )
                                 )
-                                Text("English", color = Color.White)
+                                Text(stringResource(R.string.lang_english), color = Color.White)
                             }
                         }
                     },
                     confirmButton = {
                         PrimaryButton(
-                            text = "Aplicar",
+                            text = stringResource(R.string.apply),
                             onClick = {
                                 sharedPreferences.edit().putString("language", currentLanguage).apply()
                                 setAppLocale(context, currentLanguage)
@@ -233,14 +235,14 @@ fun ConfigScreen(
                 var error by remember { mutableStateOf("" ) }
 
                 BaseDialog(
-                    title = "Cambiar PIN",
+                    title = stringResource(R.string.config_change_pin),
                     onDismiss = { showChangePinDialog = false },
                     content = {
                         Column(horizontalAlignment = Alignment.CenterHorizontally) {
                             OutlinedTextField(
                                 value = currentPin,
                                 onValueChange = { if (it.length <= 6) currentPin = it },
-                                label = { Text("PIN actual", color = Color.White) },
+                                label = { Text(stringResource(R.string.current_pin), color = Color.White) },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                                 colors = TextFieldDefaults.colors(
                                     focusedContainerColor = Color.Transparent,
@@ -262,7 +264,7 @@ fun ConfigScreen(
                             OutlinedTextField(
                                 value = newPin,
                                 onValueChange = { if (it.length <= 6) newPin = it },
-                                label = { Text("Nuevo PIN", color = Color.White) },
+                                label = { Text(stringResource(R.string.new_pin), color = Color.White) },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                                 colors = TextFieldDefaults.colors(
                                     focusedContainerColor = Color.Transparent,
@@ -284,7 +286,7 @@ fun ConfigScreen(
                             OutlinedTextField(
                                 value = confirmPin,
                                 onValueChange = { if (it.length <= 6) confirmPin = it },
-                                label = { Text("Confirmar PIN", color = Color.White) },
+                                label = { Text(stringResource(R.string.confirm_pin), color = Color.White) },
                                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                                 colors = TextFieldDefaults.colors(
                                     focusedContainerColor = Color.Transparent,
@@ -309,7 +311,7 @@ fun ConfigScreen(
                     },
                     confirmButton = {
                         PrimaryButton(
-                            text = "Guardar",
+                            text = stringResource(R.string.save),
                             onClick = {
                                 val savedPin = EncryptedPrefs.getPin(context)
                                 if (currentPin == savedPin && newPin.length == 6 && newPin == confirmPin) {
@@ -317,7 +319,7 @@ fun ConfigScreen(
                                     EncryptedPrefs.saveLastPins(context, newPin)
                                     showChangePinDialog = false
                                 } else {
-                                    error = "Datos incorrectos"
+                                    error = context.getString(R.string.incorrect_data)
                                 }
                             }
                         )

--- a/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SavedImagesScreen.kt
@@ -23,12 +23,14 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import coil.compose.rememberAsyncImagePainter
 import com.example.capilux.ui.theme.backgroundGradient
 import com.example.capilux.utils.deleteImageFile
 import com.example.capilux.utils.saveImageToGallery
 import java.io.File
+import com.example.capilux.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,10 +47,10 @@ fun SavedImagesScreen(navController: NavHostController, useAltTheme: Boolean) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Imágenes guardadas", color = Color.White) },
+                title = { Text(stringResource(R.string.saved_images_title), color = Color.White) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atrás", tint = Color.White)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(R.string.back), tint = Color.White)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -69,7 +71,7 @@ fun SavedImagesScreen(navController: NavHostController, useAltTheme: Boolean) {
             verticalArrangement = Arrangement.Top
         ) {
             if (images.isEmpty()) {
-                Text("No hay imágenes guardadas", color = Color.White)
+                Text(stringResource(R.string.no_saved_images), color = Color.White)
             } else {
                 LazyColumn(modifier = Modifier.fillMaxWidth()) {
                     items(images) { uriString ->
@@ -96,14 +98,14 @@ fun SavedImagesScreen(navController: NavHostController, useAltTheme: Boolean) {
                                     val file = uriToFile(context, Uri.parse(uriString))
                                     saveImageToGallery(context, file)
                                 }) {
-                                    Icon(Icons.Filled.Download, contentDescription = "Descargar", tint = Color.White)
+                                    Icon(Icons.Filled.Download, contentDescription = stringResource(R.string.download), tint = Color.White)
                                 }
                                 IconButton(onClick = {
                                     deleteImageFile(context, uriString)
                                     images.remove(uriString)
                                     prefs.edit().putStringSet("images", images.toSet()).apply()
                                 }) {
-                                    Icon(Icons.Filled.Delete, contentDescription = "Eliminar", tint = Color.White)
+                                    Icon(Icons.Filled.Delete, contentDescription = stringResource(R.string.delete), tint = Color.White)
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/capilux/screen/style/GeneratedImageScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/style/GeneratedImageScreen.kt
@@ -17,10 +17,11 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import com.example.capilux.SharedViewModel
 import com.example.capilux.network.CapiluxApi
-import com.example.capilux.utils.saveImageToGallery
+import com.example.capilux.utils.saveImageToSavedImages
 import com.example.capilux.ui.theme.backgroundGradient
 import com.example.capilux.components.LoadingOverlay
 import androidx.compose.material3.Card
@@ -29,6 +30,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.shape.RoundedCornerShape
 import kotlinx.coroutines.launch
 import java.io.File
+import com.example.capilux.R
 
 @Composable
 fun GeneratedImageScreen(
@@ -40,7 +42,8 @@ fun GeneratedImageScreen(
     val context = LocalContext.current
     val gradient = backgroundGradient(useAltTheme)
     val file = File(context.filesDir, "resultado_sd.png")
-    val promptVisible = sharedViewModel.selectedPrompt ?: "Estilo generado"
+    val promptDefault = stringResource(R.string.generated_style_default)
+    val promptVisible = sharedViewModel.selectedPrompt ?: promptDefault
     var loading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val coroutineScope = rememberCoroutineScope()
@@ -63,7 +66,7 @@ fun GeneratedImageScreen(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Text(
-                text = "Estilo aplicado: $promptVisible",
+                text = stringResource(R.string.generated_style_applied, promptVisible),
                 style = MaterialTheme.typography.titleLarge,
                 color = Color.White
             )
@@ -87,7 +90,7 @@ fun GeneratedImageScreen(
                     )
                 }
             } else {
-                Text("❌ No se encontró la imagen generada", color = Color.Red)
+                Text(stringResource(R.string.generated_image_not_found), color = Color.Red)
             }
 
             errorMessage?.let {
@@ -109,16 +112,19 @@ fun GeneratedImageScreen(
                 },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Volver al inicio")
+                Text(stringResource(R.string.back_to_home))
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
             Button(
-                onClick = { saveImageToGallery(context, file) },
+                onClick = {
+                    saveImageToSavedImages(context, file)
+                    navController.navigate("savedImages")
+                },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Guardar imagen")
+                Text(stringResource(R.string.save_image))
             }
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -129,7 +135,7 @@ fun GeneratedImageScreen(
                     val maskFile = File(context.filesDir, "mascara_tmp.png")
                     val prompt = promptVisible
                     if (!imageFile.exists() || !maskFile.exists()) {
-                        errorMessage = "No se encontró la imagen o la máscara original."
+                        errorMessage = context.getString(R.string.regenerate_missing_image_mask)
                         return@Button
                     }
                     loading = true
@@ -146,11 +152,11 @@ fun GeneratedImageScreen(
                                     errorMessage = null
                                 },
                                 onError = { mensaje ->
-                                    errorMessage = "Error al regenerar: $mensaje"
+                                    errorMessage = context.getString(R.string.regenerate_error, mensaje)
                                 }
                             )
                         } catch (e: Exception) {
-                            errorMessage = "Error inesperado: ${e.message}"
+                            errorMessage = context.getString(R.string.unexpected_error, e.message ?: "")
                         } finally {
                             loading = false
                         }
@@ -158,12 +164,12 @@ fun GeneratedImageScreen(
                 },
                 modifier = Modifier.fillMaxWidth()
             ) {
-                Text("Regenerar resultado")
+                Text(stringResource(R.string.regenerate_result))
             }
         }
 
         if (loading) {
-            LoadingOverlay(message = "Regenerando imagen...", useAltTheme = useAltTheme)
+            LoadingOverlay(message = stringResource(R.string.regenerating_image), useAltTheme = useAltTheme)
         }
     }
 }

--- a/app/src/main/java/com/example/capilux/utils/ImageUtils.kt
+++ b/app/src/main/java/com/example/capilux/utils/ImageUtils.kt
@@ -63,6 +63,25 @@ fun saveImageToGallery(context: Context, imageFile: File): Boolean {
     }
 }
 
+// 💾 Guarda una imagen en el almacenamiento interno y la registra en la lista de guardadas
+fun saveImageToSavedImages(context: Context, imageFile: File): Boolean {
+    return try {
+        val savedDir = File(context.filesDir, "saved_images").apply { mkdirs() }
+        val savedFile = File(savedDir, "image_${System.currentTimeMillis()}.jpg")
+        imageFile.copyTo(savedFile, overwrite = true)
+
+        val prefs = context.getSharedPreferences("saved_images", Context.MODE_PRIVATE)
+        val images = prefs.getStringSet("images", mutableSetOf())?.toMutableSet() ?: mutableSetOf()
+        images.add(Uri.fromFile(savedFile).toString())
+        prefs.edit().putStringSet("images", images).apply()
+
+        true
+    } catch (e: Exception) {
+        Log.e("ImageUtils", "Error guardando imagen: ${e.message}")
+        false
+    }
+}
+
 // 🗑️ Elimina un archivo de imagen local
 fun deleteImageFile(context: Context, uriString: String): Boolean {
     return try {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,35 @@
+<resources>
+    <string name="app_name">Capilux</string>
+    <string name="config_title">Settings</string>
+    <string name="back">Back</string>
+    <string name="config_name_label">Name</string>
+    <string name="config_section_settings">Settings</string>
+    <string name="config_gradient">Gradient</string>
+    <string name="config_language">Language</string>
+    <string name="lang_spanish">Spanish</string>
+    <string name="lang_english">English</string>
+    <string name="config_change_pin">Change PIN</string>
+    <string name="config_save_changes">Save changes</string>
+    <string name="config_select_language">Select language</string>
+    <string name="apply">Apply</string>
+    <string name="current_pin">Current PIN</string>
+    <string name="new_pin">New PIN</string>
+    <string name="confirm_pin">Confirm PIN</string>
+    <string name="save">Save</string>
+    <string name="incorrect_data">Incorrect data</string>
+    <string name="generated_style_default">Generated style</string>
+    <string name="generated_style_applied">Applied style: %1$s</string>
+    <string name="generated_image_not_found">❌ Generated image not found</string>
+    <string name="back_to_home">Back to home</string>
+    <string name="save_image">Save image</string>
+    <string name="regenerate_missing_image_mask">Original image or mask not found.</string>
+    <string name="regenerate_error">Error regenerating: %1$s</string>
+    <string name="unexpected_error">Unexpected error: %1$s</string>
+    <string name="regenerate_result">Regenerate result</string>
+    <string name="regenerating_image">Regenerating image...</string>
+    <string name="saved_images_title">Saved images</string>
+    <string name="no_saved_images">No saved images</string>
+    <string name="download">Download</string>
+    <string name="delete">Delete</string>
+</resources>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,35 @@
 <resources>
     <string name="app_name">Capilux</string>
+    <string name="config_title">Configuración</string>
+    <string name="back">Atrás</string>
+    <string name="config_name_label">Nombre</string>
+    <string name="config_section_settings">Configuraciones</string>
+    <string name="config_gradient">Degradado</string>
+    <string name="config_language">Idioma</string>
+    <string name="lang_spanish">Español</string>
+    <string name="lang_english">English</string>
+    <string name="config_change_pin">Cambiar PIN</string>
+    <string name="config_save_changes">Guardar cambios</string>
+    <string name="config_select_language">Seleccionar idioma</string>
+    <string name="apply">Aplicar</string>
+    <string name="current_pin">PIN actual</string>
+    <string name="new_pin">Nuevo PIN</string>
+    <string name="confirm_pin">Confirmar PIN</string>
+    <string name="save">Guardar</string>
+    <string name="incorrect_data">Datos incorrectos</string>
+    <string name="generated_style_default">Estilo generado</string>
+    <string name="generated_style_applied">Estilo aplicado: %1$s</string>
+    <string name="generated_image_not_found">❌ No se encontró la imagen generada</string>
+    <string name="back_to_home">Volver al inicio</string>
+    <string name="save_image">Guardar imagen</string>
+    <string name="regenerate_missing_image_mask">No se encontró la imagen o la máscara original.</string>
+    <string name="regenerate_error">Error al regenerar: %1$s</string>
+    <string name="unexpected_error">Error inesperado: %1$s</string>
+    <string name="regenerate_result">Regenerar resultado</string>
+    <string name="regenerating_image">Regenerando imagen...</string>
+    <string name="saved_images_title">Imágenes guardadas</string>
+    <string name="no_saved_images">No hay imágenes guardadas</string>
+    <string name="download">Descargar</string>
+    <string name="delete">Eliminar</string>
 </resources>
+


### PR DESCRIPTION
## Summary
- add English string resources and use them across configuration, generated image, and saved images screens
- save generated images into internal Saved Images list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68935acc7b7483268a335adbc094e06e