### PR TITLE
Add missing bilingual strings and terms acceptance

### DIFF
--- a/app/src/main/java/com/example/capilux/components/Dialogs.kt
+++ b/app/src/main/java/com/example/capilux/components/Dialogs.kt
@@ -51,7 +51,7 @@ import com.example.capilux.ui.theme.PrimaryButton
 import com.example.capilux.ui.theme.backgroundGradient
 
 @Composable
-fun TermsAndConditionsDialog(onDismiss: () -> Unit, useAltTheme: Boolean) {
+fun TermsAndConditionsDialog(onAccept: () -> Unit, useAltTheme: Boolean) {
     // Gradiente para el fondo principal que respeta la configuración
     val gradient = backgroundGradient(useAltTheme)
 
@@ -59,8 +59,8 @@ fun TermsAndConditionsDialog(onDismiss: () -> Unit, useAltTheme: Boolean) {
     val scrollState = rememberScrollState()
 
     Dialog(
-        onDismissRequest = onDismiss,
-        properties = DialogProperties(dismissOnBackPress = true, dismissOnClickOutside = false)
+        onDismissRequest = {},
+        properties = DialogProperties(dismissOnBackPress = false, dismissOnClickOutside = false)
     ) {
         Surface(
             modifier = Modifier
@@ -179,7 +179,7 @@ fun TermsAndConditionsDialog(onDismiss: () -> Unit, useAltTheme: Boolean) {
                 ) {
                     PrimaryButton(
                         text = stringResource(R.string.accept_terms_button),
-                        onClick = onDismiss
+                        onClick = onAccept
                     )
                 }
             }

--- a/app/src/main/java/com/example/capilux/components/PhotoRecommendationDialog.kt
+++ b/app/src/main/java/com/example/capilux/components/PhotoRecommendationDialog.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.res.stringResource
+import com.example.capilux.R
 
 @Composable
 fun PhotoRecommendationDialog(onDismiss: () -> Unit) {
@@ -45,7 +47,7 @@ fun PhotoRecommendationDialog(onDismiss: () -> Unit) {
             ) {
                 // Encabezado
                 Text(
-                    "Recomendaciones para tomar tu foto",
+                    stringResource(R.string.photo_recommendation_title),
                     color = Color.White,
                     fontSize = 22.sp,
                     fontWeight = FontWeight.Bold
@@ -55,9 +57,10 @@ fun PhotoRecommendationDialog(onDismiss: () -> Unit) {
 
                 // Contenido del diálogo con las recomendaciones
                 listOf(
-                    "1. Centra tu rostro en el encuadre.",
-                    "2. Asegúrate de que tu rostro esté bien iluminado.",
-                    "3. Mira hacia adelante y no muevas la cabeza."
+                    stringResource(R.string.photo_recommendation_1),
+                    stringResource(R.string.photo_recommendation_2),
+                    stringResource(R.string.photo_recommendation_3),
+                    stringResource(R.string.photo_recommendation_4)
                 ).forEach { recommendation ->
                     Text(
                         text = recommendation,
@@ -78,7 +81,7 @@ fun PhotoRecommendationDialog(onDismiss: () -> Unit) {
                     colors = ButtonDefaults.buttonColors(containerColor = Color.White)
                 ) {
                     Text(
-                        "Cerrar",
+                        stringResource(R.string.close),
                         color = Color(0xFF2D0C5A),
                         fontWeight = FontWeight.Bold
                     )

--- a/app/src/main/java/com/example/capilux/screen/ConfirmPhotoScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/ConfirmPhotoScreen.kt
@@ -21,6 +21,8 @@ import com.example.capilux.SharedViewModel
 import com.example.capilux.ui.theme.backgroundGradient
 import com.example.capilux.utils.saveImageToPrivateStorage
 import java.io.File
+import androidx.compose.ui.res.stringResource
+import com.example.capilux.R
 
 @Composable
 fun ConfirmPhotoScreen(
@@ -73,7 +75,7 @@ fun ConfirmPhotoScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             Text(
-                text = "¿La foto está bien?",
+                text = stringResource(R.string.photo_ok_question),
                 color = Color.White,
                 style = MaterialTheme.typography.titleMedium
             )
@@ -85,7 +87,7 @@ fun ConfirmPhotoScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Button(onClick = { navController.popBackStack() }) {
-                    Text("Volver a tomar")
+                    Text(stringResource(R.string.retake_photo))
                 }
                 Button(onClick = {
                     if (privateFilePath == null || !File(privateFilePath!!).exists()) {
@@ -96,7 +98,7 @@ fun ConfirmPhotoScreen(
                         }
                     }
                 }) {
-                    Text("Siguiente")
+                    Text(stringResource(R.string.next))
                 }
             }
         }
@@ -105,11 +107,11 @@ fun ConfirmPhotoScreen(
     if (showDialog.value) {
         AlertDialog(
             onDismissRequest = { showDialog.value = false },
-            title = { Text("Error") },
-            text = { Text("No se encontró la imagen, vuelve a tomarla o selecciona otra.") },
+            title = { Text(stringResource(R.string.error)) },
+            text = { Text(stringResource(R.string.image_not_found_message)) },
             confirmButton = {
                 Button(onClick = { showDialog.value = false }) {
-                    Text("OK")
+                    Text(stringResource(R.string.ok))
                 }
             }
         )

--- a/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/SupportScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -55,10 +56,10 @@ fun SupportScreen(navController: NavHostController, useAltTheme: Boolean) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Ayuda y soporte", color = Color.White) },
+                title = { Text(stringResource(R.string.drawer_help_support), color = Color.White) },
                 navigationIcon = {
                     IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Atrás", tint = Color.White)
+                        Icon(Icons.Filled.ArrowBack, contentDescription = stringResource(R.string.back), tint = Color.White)
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -80,28 +81,28 @@ fun SupportScreen(navController: NavHostController, useAltTheme: Boolean) {
         ) {
             Image(
                 painter = painterResource(id = R.drawable.logo),
-                contentDescription = "Logo Capilux",
+                contentDescription = stringResource(R.string.support_logo_description),
                 modifier = Modifier
                     .size(140.dp)
                     .offset(y = offsetY.dp)
             )
             Spacer(modifier = Modifier.size(24.dp))
             Text(
-                text = "¿Necesitas ayuda? Contáctanos en:",
+                text = stringResource(R.string.support_contact_prompt),
                 color = Color.White,
                 style = MaterialTheme.typography.bodyLarge,
                 textAlign = TextAlign.Center
             )
             Spacer(modifier = Modifier.size(12.dp))
             Text(
-                text = "soporte@capilux.com",
+                text = stringResource(R.string.support_email),
                 color = Color.White,
                 fontWeight = FontWeight.Bold,
                 fontSize = 18.sp
             )
             Spacer(modifier = Modifier.size(4.dp))
             Text(
-                text = "Teléfono: +1 234 567 890",
+                text = stringResource(R.string.support_phone),
                 color = Color.White,
                 style = MaterialTheme.typography.bodyLarge
             )

--- a/app/src/main/java/com/example/capilux/screen/UserCreationScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/UserCreationScreen.kt
@@ -237,7 +237,10 @@ fun UserCreationScreen(navController: NavHostController, useAltTheme: Boolean, u
 
             if (showTermsDialog) {
                 TermsAndConditionsDialog(
-                    onDismiss = { showTermsDialog = false },
+                    onAccept = {
+                        showTermsDialog = false
+                        isTermsAccepted = true
+                    },
                     useAltTheme = useAltTheme
                 )
             }

--- a/app/src/main/java/com/example/capilux/screen/mask/MaskPreviewScreen.kt
+++ b/app/src/main/java/com/example/capilux/screen/mask/MaskPreviewScreen.kt
@@ -26,6 +26,8 @@ import androidx.navigation.NavHostController
 import androidx.compose.foundation.BorderStroke
 import com.example.capilux.ui.theme.backgroundGradient
 import java.io.File
+import androidx.compose.ui.res.stringResource
+import com.example.capilux.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -45,7 +47,7 @@ fun MaskPreviewScreen(
             CenterAlignedTopAppBar(
                 title = {
                     Text(
-                        text = "Previsualización",
+                        text = stringResource(R.string.mask_preview_title),
                         color = Color.White,
                         style = MaterialTheme.typography.titleLarge
                     )
@@ -54,7 +56,7 @@ fun MaskPreviewScreen(
                     IconButton(onClick = { navController.popBackStack() }) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
-                            contentDescription = "Volver",
+                            contentDescription = stringResource(R.string.back),
                             tint = Color.White
                         )
                     }
@@ -83,7 +85,7 @@ fun MaskPreviewScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Imagen Original",
+                    text = stringResource(R.string.original_image),
                     color = Color.White.copy(alpha = 0.9f),
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier.padding(bottom = 8.dp)
@@ -91,7 +93,7 @@ fun MaskPreviewScreen(
 
                 ImageWithScroll(
                     file = originalFile,
-                    errorText = "Sin imagen original"
+                    errorText = stringResource(R.string.no_original_image)
                 )
             }
 
@@ -110,7 +112,7 @@ fun MaskPreviewScreen(
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = "Transformación aplicada",
+                    text = stringResource(R.string.transformation_applied),
                     color = Color.White.copy(alpha = 0.7f),
                     style = MaterialTheme.typography.labelMedium
                 )
@@ -133,7 +135,7 @@ fun MaskPreviewScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
-                    text = "Máscara Generada",
+                    text = stringResource(R.string.generated_mask),
                     color = Color.White.copy(alpha = 0.9f),
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier.padding(bottom = 8.dp)
@@ -141,7 +143,7 @@ fun MaskPreviewScreen(
 
                 ImageWithScroll(
                     file = maskFile,
-                    errorText = "Máscara no disponible"
+                    errorText = stringResource(R.string.mask_not_available)
                 )
             }
 
@@ -168,7 +170,7 @@ fun MaskPreviewScreen(
                     ),
                     shape = RoundedCornerShape(12.dp)
                 ) {
-                    Text("Confirmar y Continuar", style = MaterialTheme.typography.labelLarge)
+                    Text(stringResource(R.string.confirm_and_continue), style = MaterialTheme.typography.labelLarge)
                 }
 
                 // Special design for generate new mask button
@@ -190,7 +192,7 @@ fun MaskPreviewScreen(
                         modifier = Modifier.size(18.dp)
                     )
                     Spacer(Modifier.width(8.dp))
-                    Text("Generar Nueva Máscara", style = MaterialTheme.typography.labelLarge)
+                    Text(stringResource(R.string.generate_new_mask), style = MaterialTheme.typography.labelLarge)
                 }
             }
 
@@ -225,7 +227,7 @@ private fun ImageWithScroll(
             ) {
                 Image(
                     bitmap = bitmap.asImageBitmap(),
-                    contentDescription = "Preview",
+                    contentDescription = stringResource(R.string.mask_preview_title),
                     modifier = Modifier.fillMaxWidth(),
                     contentScale = ContentScale.Fit
                 )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -140,5 +140,31 @@
     <string name="setup_security_title">Set up security questions</string>
 
 
+    <string name="photo_recommendation_title">Tips for taking your photo</string>
+    <string name="photo_recommendation_1">1. Center your face in the frame.</string>
+    <string name="photo_recommendation_2">2. Ensure your face is well lit.</string>
+    <string name="photo_recommendation_3">3. Look forward and keep your head still.</string>
+    <string name="photo_recommendation_4">4. Make sure your hair is loose.</string>
+    <string name="close">Close</string>
+    <string name="support_contact_prompt">Need help? Contact us at:</string>
+    <string name="support_email">support@capilux.com</string>
+    <string name="support_phone">Phone: +1 234 567 890</string>
+    <string name="support_logo_description">Capilux logo</string>
+    <string name="photo_ok_question">Is the photo okay?</string>
+    <string name="retake_photo">Retake</string>
+    <string name="next">Next</string>
+    <string name="image_not_found_message">Image not found, please retake or choose another.</string>
+    <string name="mask_preview_title">Preview</string>
+    <string name="original_image">Original Image</string>
+    <string name="no_original_image">No original image</string>
+    <string name="transformation_applied">Transformation applied</string>
+    <string name="generated_mask">Generated Mask</string>
+    <string name="mask_not_available">Mask not available</string>
+    <string name="confirm_and_continue">Confirm and Continue</string>
+    <string name="generate_new_mask">Generate New Mask</string>
+    <string name="selected_style">Selected style</string>
+    <string name="style_selection_title">Select a style</string>
+    <string name="recommended_styles">Recommended styles</string>
+    <string name="recommended_styles_for">Recommended styles for %1$s</string>
+    <string name="missing_image_mask">Image or mask not found.</string>
 </resources>
-

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -138,5 +138,32 @@
     <string name="security_question_food">¿Cuál es tu comida favorita?</string>
     <string name="security_question_friend">¿Cuál es el nombre de tu mejor amigo de la infancia?</string>
     <string name="setup_security_title">Configurar preguntas de seguridad</string>
+    <string name="photo_recommendation_title">Recomendaciones para tomar tu foto</string>
+    <string name="photo_recommendation_1">1. Centra tu rostro en el encuadre.</string>
+    <string name="photo_recommendation_2">2. Asegúrate de que tu rostro esté bien iluminado.</string>
+    <string name="photo_recommendation_3">3. Mira hacia adelante y no muevas la cabeza.</string>
+    <string name="photo_recommendation_4">4. Asegúrate de que tu cabello esté suelto.</string>
+    <string name="close">Cerrar</string>
+    <string name="support_contact_prompt">¿Necesitas ayuda? Contáctanos en:</string>
+    <string name="support_email">soporte@capilux.com</string>
+    <string name="support_phone">Teléfono: +1 234 567 890</string>
+    <string name="support_logo_description">Logo Capilux</string>
+    <string name="photo_ok_question">¿La foto está bien?</string>
+    <string name="retake_photo">Volver a tomar</string>
+    <string name="next">Siguiente</string>
+    <string name="image_not_found_message">No se encontró la imagen, vuelve a tomarla o selecciona otra.</string>
+    <string name="mask_preview_title">Previsualización</string>
+    <string name="original_image">Imagen Original</string>
+    <string name="no_original_image">Sin imagen original</string>
+    <string name="transformation_applied">Transformación aplicada</string>
+    <string name="generated_mask">Máscara Generada</string>
+    <string name="mask_not_available">Máscara no disponible</string>
+    <string name="confirm_and_continue">Confirmar y Continuar</string>
+    <string name="generate_new_mask">Generar Nueva Máscara</string>
+    <string name="selected_style">Estilo seleccionado</string>
+    <string name="style_selection_title">Selecciona un estilo</string>
+    <string name="recommended_styles">Estilos recomendados</string>
+    <string name="recommended_styles_for">Estilos recomendados para %1$s</string>
+    <string name="missing_image_mask">No se encontró la imagen o la máscara.</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- localize photo tips, support, mask preview, and photo confirmation screens in English and Spanish
- add loose hair tip and recommended style strings
- auto-check T&C checkbox upon accepting terms

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_68996be2f9e08321b1a6c8fd48d55e19